### PR TITLE
Fix port typo in collectd.asciidoc

### DIFF
--- a/docs/plugins/codecs/collectd.asciidoc
+++ b/docs/plugins/codecs/collectd.asciidoc
@@ -8,7 +8,7 @@ Configuration in your Logstash configuration file can be as simple as:
 [source,ruby]
     input {
       udp {
-        port => 28526
+        port => 25826
         buffer_size => 1452
         codec => collectd { }
       }


### PR DESCRIPTION
I believe there is a typo in the example config.