### PR TITLE
Date + GBQ doc updates

### DIFF
--- a/docs/plugins/filters/date.asciidoc
+++ b/docs/plugins/filters/date.asciidoc
@@ -184,7 +184,7 @@ For example, if you have a field `logdate`, with a value that looks like
 
 If your field is nested in your structure, you can use the nested
 syntax `[foo][bar]` to match its value. For more information, please refer to
-http://www.elasticsearch.org/guide/en/logstash/current/_logstash_config_language.html#_field_references
+<<logstash-config-field-references>>
 
 [[plugins-filters-date-periodic_flush]]
 ===== `periodic_flush` 

--- a/docs/plugins/outputs/google_bigquery.asciidoc
+++ b/docs/plugins/outputs/google_bigquery.asciidoc
@@ -2,7 +2,7 @@
 === google_bigquery
 
 
-NOTE: This is a community-contributed plugin! It does not ship with logstash by default, but it is easy to install! To use this, you must have installed the contrib plugins package.
+NOTE: This is a community-maintained plugin! It does not ship with Logstash by default, but it is easy to install by running `bin/plugin install logstash-output-google_bigquery`.
 
 
 Author: Rodrigo De Castro <rdc@google.com>


### PR DESCRIPTION
Fix date filter markup to use asciidoc reference style.
Correct NOTE: text for community-maintained plugins (google_bigquery example)
