### PR TITLE
Update pluginbody.asciidoc

### DIFF
--- a/docs/static/include/pluginbody.asciidoc
+++ b/docs/static/include/pluginbody.asciidoc
@@ -810,7 +810,7 @@ TIP: See http://bundler.io/gemfile.html[Bundler's Gemfile page] for more details
 ----------------------------------
 source 'https://rubygems.org'
 gemspec
-gem "logstash", :github => "elasticsearch/logstash", :branch => "{branch}"
+gem "logstash", :git => "http://github.com/elasticsearch/logstash", :branch => "{branch}"
 ----------------------------------
 
 [float]


### PR DESCRIPTION
github => 
does not work in many corporate networks because it's blocked, it needs to be changed to git => "http://github.com/......"